### PR TITLE
Fix template loading when running from other directories

### DIFF
--- a/collatz.py
+++ b/collatz.py
@@ -5,11 +5,18 @@ import argparse
 import errno
 import os
 from dataclasses import dataclass
+from pathlib import Path
 from typing import List, Tuple
 
 from flask import Flask, jsonify, render_template, request
 
-app = Flask(__name__)
+BASE_DIR = Path(__file__).resolve().parent
+
+app = Flask(
+    __name__,
+    template_folder=str(BASE_DIR / "templates"),
+    static_folder=str(BASE_DIR / "static"),
+)
 
 MAX_STEPS = 1000
 


### PR DESCRIPTION
## Summary
- configure the Flask app with explicit template and static directory paths
- ensure the web UI loads correctly even when the server is launched from another working directory

## Testing
- curl -I http://127.0.0.1:5001/


------
https://chatgpt.com/codex/tasks/task_e_68d4d5a6509c832a8a81247bb35d604c